### PR TITLE
[Feature] WIP: support sequence parallel

### DIFF
--- a/configs/ffs/ffs_img_train_sp2.yaml
+++ b/configs/ffs/ffs_img_train_sp2.yaml
@@ -23,7 +23,7 @@ learn_sigma: True # important
 extras: 1 # [1, 2] 1 unconditional generation, 2 class-conditional generation
 
 # train config:
-sequence_parallel_size: 1
+sequence_parallel_size: 2
 save_ceph: True # important
 use_image_num: 8
 learning_rate: 1e-4

--- a/diffusion/gaussian_diffusion.py
+++ b/diffusion/gaussian_diffusion.py
@@ -9,8 +9,6 @@ import math
 import numpy as np
 import torch as th
 import enum
-from xtuner.parallel.sequence import reduce_sequence_parallel_loss, split_for_sequence_parallel
-import torch
 
 from .diffusion_utils import discretized_gaussian_log_likelihood, normal_kl
 
@@ -734,7 +732,7 @@ class GaussianDiffusion:
             model_kwargs = {}
         if noise is None:
             noise = th.randn_like(x_start)
-        x_t = self.q_sample(x_start, t, noise=noise)  # x: (bs, frame, c_in, h, w), t: (bs, )
+        x_t = self.q_sample(x_start, t, noise=noise)
 
         terms = {}
 
@@ -750,7 +748,7 @@ class GaussianDiffusion:
             if self.loss_type == LossType.RESCALED_KL:
                 terms["loss"] *= self.num_timesteps
         elif self.loss_type == LossType.MSE or self.loss_type == LossType.RESCALED_MSE:
-            model_output = model(x_t, t, **model_kwargs)  # (bs, frame, 2*c_in, h, w)
+            model_output = model(x_t, t, **model_kwargs)
             # try:
             #     model_output = model(x_t, t, **model_kwargs).sample # for tav unet
             # except:

--- a/models/latte_img.py
+++ b/models/latte_img.py
@@ -16,10 +16,8 @@ import torch.distributed as dist
 from einops import rearrange, repeat
 from timm.models.vision_transformer import Mlp, PatchEmbed
 from xtuner.parallel.sequence import (
-    get_sequence_parallel_world_size, split_for_sequence_parallel, 
-    get_sequence_parallel_group, gather_forward_split_backward,
-    post_process_for_sequence_parallel_attn, pre_process_for_sequence_parallel_attn,
-    split_forward_gather_backward, all_to_all)
+    get_sequence_parallel_world_size, get_sequence_parallel_group, 
+    gather_forward_split_backward, split_forward_gather_backward, all_to_all)
 
 import os
 import sys

--- a/train_with_img.py
+++ b/train_with_img.py
@@ -37,46 +37,7 @@ from utils import (clip_grad_norm_, create_logger, update_ema,
                    write_tensorboard, setup_distributed, get_experiment_dir)
 
 
-from xtuner.parallel.sequence import (
-    init_sequence_parallel, get_sequence_parallel_world_size,
-    get_sequence_parallel_rank, get_data_parallel_world_size, 
-    get_data_parallel_rank, SequenceParallelSampler)
-
-
-# class SequenceParallelSampler(DistributedSampler):
-#     def __init__(self, dataset, num_replicas = None,
-#                  rank = None, shuffle: bool = True,
-#                  seed: int = 0, drop_last: bool = False):
-#         if num_replicas is None:
-#             if not dist.is_available():
-#                 raise RuntimeError("Requires distributed package to be available")
-#             num_replicas = get_data_parallel_world_size()
-#         if rank is None:
-#             if not dist.is_available():
-#                 raise RuntimeError("Requires distributed package to be available")
-#             rank = get_data_parallel_rank()
-#         if rank >= num_replicas or rank < 0:
-#             raise ValueError(
-#                 f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
-#         self.dataset = dataset
-#         self.num_replicas = num_replicas
-#         self.rank = rank
-#         self.epoch = 0
-#         self.drop_last = drop_last
-#         # If the dataset length is evenly divisible by # of replicas, then there
-#         # is no need to drop any data, since the dataset will be split equally.
-#         if self.drop_last and len(self.dataset) % self.num_replicas != 0:  # type: ignore[arg-type]
-#             # Split to nearest available length that is evenly divisible.
-#             # This is to ensure each rank receives the same amount of data when
-#             # using this Sampler.
-#             self.num_samples = math.ceil(
-#                 (len(self.dataset) - self.num_replicas) / self.num_replicas  # type: ignore[arg-type]
-#             )
-#         else:
-#             self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)  # type: ignore[arg-type]
-#         self.total_size = self.num_samples * self.num_replicas
-#         self.shuffle = shuffle
-#         self.seed = seed
+from xtuner.parallel.sequence import init_sequence_parallel, SequenceParallelSampler
 
 #################################################################################
 #                                  Training Loop                                #

--- a/train_with_img.py
+++ b/train_with_img.py
@@ -37,6 +37,47 @@ from utils import (clip_grad_norm_, create_logger, update_ema,
                    write_tensorboard, setup_distributed, get_experiment_dir)
 
 
+from xtuner.parallel.sequence import (
+    init_sequence_parallel, get_sequence_parallel_world_size,
+    get_sequence_parallel_rank, get_data_parallel_world_size, 
+    get_data_parallel_rank, SequenceParallelSampler)
+
+
+# class SequenceParallelSampler(DistributedSampler):
+#     def __init__(self, dataset, num_replicas = None,
+#                  rank = None, shuffle: bool = True,
+#                  seed: int = 0, drop_last: bool = False):
+#         if num_replicas is None:
+#             if not dist.is_available():
+#                 raise RuntimeError("Requires distributed package to be available")
+#             num_replicas = get_data_parallel_world_size()
+#         if rank is None:
+#             if not dist.is_available():
+#                 raise RuntimeError("Requires distributed package to be available")
+#             rank = get_data_parallel_rank()
+#         if rank >= num_replicas or rank < 0:
+#             raise ValueError(
+#                 f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
+#         self.dataset = dataset
+#         self.num_replicas = num_replicas
+#         self.rank = rank
+#         self.epoch = 0
+#         self.drop_last = drop_last
+#         # If the dataset length is evenly divisible by # of replicas, then there
+#         # is no need to drop any data, since the dataset will be split equally.
+#         if self.drop_last and len(self.dataset) % self.num_replicas != 0:  # type: ignore[arg-type]
+#             # Split to nearest available length that is evenly divisible.
+#             # This is to ensure each rank receives the same amount of data when
+#             # using this Sampler.
+#             self.num_samples = math.ceil(
+#                 (len(self.dataset) - self.num_replicas) / self.num_replicas  # type: ignore[arg-type]
+#             )
+#         else:
+#             self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)  # type: ignore[arg-type]
+#         self.total_size = self.num_samples * self.num_replicas
+#         self.shuffle = shuffle
+#         self.seed = seed
+
 #################################################################################
 #                                  Training Loop                                #
 #################################################################################
@@ -47,6 +88,7 @@ def main(args):
 
     # Setup DDP:
     setup_distributed()
+    init_sequence_parallel(args.sequence_parallel_size)
     # dist.init_process_group("nccl")
     # assert args.global_batch_size % dist.get_world_size() == 0, f"Batch size must be divisible by world size."
     # rank = dist.get_rank()
@@ -57,7 +99,8 @@ def main(args):
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device("cuda", local_rank)
 
-    seed = args.global_seed + rank
+    # seed = args.global_seed + rank
+    seed = args.global_seed
     torch.manual_seed(seed)
     torch.cuda.set_device(device)
     print(f"Starting rank={rank}, local rank={local_rank}, seed={seed}, world_size={dist.get_world_size()}.")
@@ -147,14 +190,16 @@ def main(args):
 
     # Setup data:
     dataset = get_dataset(args)
+
+    sampler = SequenceParallelSampler(dataset, shuffle=True, seed=args.global_seed)
         
-    sampler = DistributedSampler(
-        dataset,
-        num_replicas=dist.get_world_size(),
-        rank=rank,
-        shuffle=True,
-        seed=args.global_seed
-    )
+    # sampler = DistributedSampler(
+    #     dataset,
+    #     num_replicas=dist.get_world_size(),
+    #     rank=rank,
+    #     shuffle=True,
+    #     seed=args.global_seed
+    # )
     loader = DataLoader(
         dataset,
         batch_size=int(args.local_batch_size),
@@ -164,7 +209,7 @@ def main(args):
         pin_memory=True,
         drop_last=True
     )
-    logger.info(f"Dataset contains {len(dataset):,} videos ({args.webvideo_data_path})")
+    # logger.info(f"Dataset contains {len(dataset):,} videos ({args.webvideo_data_path})")
 
     # Scheduler
     lr_scheduler = get_scheduler(


### PR DESCRIPTION
序列并行设为 2 时的启动命令：
`srun -p llm_razor --job-name=intern7b --quotatype=auto --gres=gpu:8 --ntasks=8 --ntasks-per-node=8 --cpus-per-task=16 --kill-on-bad-exit=1 python train_with_img.py --config configs/ffs/ffs_img_train_sp2.yaml`
loss 情况：
![image](https://github.com/Vchitect/Latte/assets/41630003/10300e18-8248-487f-8f01-5747806be493)

序列并行设为 1 时的启动命令：
`srun -p llm_razor --job-name=intern7b --quotatype=auto --gres=gpu:4 --ntasks=4 --ntasks-per-node=4 --cpus-per-task=24 --kill-on-bad-exit=1 python train_with_img.py --config configs/ffs/ffs_img_train.yaml`
loss 情况：
![image](https://github.com/Vchitect/Latte/assets/41630003/bbea18bd-1a80-4221-b867-5e8e625c3f34)
